### PR TITLE
Add classes to parser and spec

### DIFF
--- a/isf/src/ast.rs
+++ b/isf/src/ast.rs
@@ -5,6 +5,7 @@
 #[derive(Debug, Default)]
 pub struct Ast {
     pub characteristics: Vec<Characteristic>,
+    pub classes: Vec<Class>,
     pub instructions: Vec<Instruction>,
 }
 
@@ -28,6 +29,13 @@ impl Ast {
 #[derive(PartialEq, Eq, Debug)]
 pub enum Characteristic {
     InstructionWidth(usize),
+}
+
+#[derive(Debug, Clone)]
+pub struct Class {
+    pub doc: String,
+    pub name: String,
+    pub width: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -82,8 +90,14 @@ pub struct Base {
 pub struct Field {
     pub doc: String,
     pub name: String,
-    pub width: usize,
+    pub ty: FieldType,
     pub value: Option<FieldValue>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum FieldType {
+    FixedWidth(usize),
+    Class(String),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/isf/src/docgen.rs
+++ b/isf/src/docgen.rs
@@ -52,6 +52,7 @@ pub struct Field {
     pub doc: String,
     pub name: String,
     pub width: usize,
+    pub class: Option<String>,
 }
 
 impl From<spec::Field> for Field {
@@ -60,6 +61,7 @@ impl From<spec::Field> for Field {
             doc: value.doc,
             name: value.name,
             width: value.width,
+            class: value.class.clone(),
         }
     }
 }

--- a/isf/testcase/add-reg.isf
+++ b/isf/testcase/add-reg.isf
@@ -1,0 +1,60 @@
+// Basically the same as `add.isf`, but with a `Register` type
+
+// more bits
+instruction_width = 32;
+// some other comment
+// about muffins
+
+/// General-purpose register
+class Register {
+  width: 2
+}
+
+/// Add values from two registers
+// hello
+instruction Add { // construct additional pylons
+  timing: 1 cycle // if add takes more than a cycle, we're in trouble
+  fields:
+    /// The destination register
+    dst: Register,
+    // comments can go here
+    /// The first source register
+    // or here
+    src1: Register, // or here!
+    /// The second source register
+    src2: Register,
+    /// Set a flag that sign extends the result
+    sign_extend: 1, // alpha quadrant
+
+  assembly:
+    // a comment
+    'add'['.sx' = sign_extend] 'r'dst 'r'src1 'r'src2; // ncc
+    // more commenting
+
+    // blah blah
+    examples:
+      /// Add the contents of registers 4 and 7 placing the result in
+      /// register 0.
+      // comments
+      add r0 r4 r7; // 1701
+      // comments comments
+
+      /// Add the contents of registers 4 and 7 sign-extending and
+      /// placing the result in register 0.
+      add.sx r0 r4 r7;
+
+  machine:
+    // Do you know the muffin man?
+    opcode: 7 = 2, // The muffin man?
+    sign_extend!,
+    dst,
+    _: 3,
+    // The muffin man!
+    // d
+    src1,
+    _: 3,
+    src2,
+    _: 3,
+    // yes
+}
+


### PR DESCRIPTION
This allows for more detailed specifications, e.g.
```
class Reg {
  width: 2,
}

instruction Add {
  timing: 1 cycle
  fields:
    /// The destination register
    dst: Reg,
    // etc
```

Right now, classes are parsed and passed through to `spec`; they're not yet used in codegen.