### PR TITLE
Tweaks for the softcore

### DIFF
--- a/isf/src/bits.rs
+++ b/isf/src/bits.rs
@@ -346,3 +346,21 @@ macro_rules! gen_u19 {
 }
 gen_u19!(u32);
 gen_u19!(u64);
+
+macro_rules! gen_u26 {
+    ($width:ident) => {
+        paste::item! {
+            pub fn [< get_u26_ $width >](reg: $width, offset: usize) -> u32 {
+                let v = [< get_u32_ $width >](reg, offset);
+                v & 0b11111111111111111111111111
+            }
+            pub fn [< set_u26_ $width >](reg: $width, offset: usize, value: u32) -> $width {
+                let mask = !(0b11111111111111111111111111 << (offset as $width));
+                let v = ((value as $width) & 0b11111111111111111111111111) << (offset as $width);
+                (reg & mask) | v
+            }
+        }
+    };
+}
+gen_u26!(u32);
+gen_u26!(u64);

--- a/isf/src/codegen.rs
+++ b/isf/src/codegen.rs
@@ -10,7 +10,7 @@ use std::{
     fs::read_to_string,
 };
 
-use crate::spec::{self, AssemblyElement, FieldOrder, Class, MachineElement};
+use crate::spec::{self, AssemblyElement, Class, FieldOrder, MachineElement};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::Ident;
@@ -34,15 +34,17 @@ pub fn generate_code(path: &str) -> anyhow::Result<String> {
 /// generated structs implement the [`AssemblyInstruction`] and
 /// [`MachineInstruction`] traits. They also contain getter and setter
 /// methods for each field.
-pub fn generate(
-    spec: &spec::Spec,
-) -> TokenStream {
+pub fn generate(spec: &spec::Spec) -> TokenStream {
     let mut tokens = TokenStream::default();
     let storage = uint_size(spec.instruction_width);
 
     for instruction in &spec.instructions {
-        let instr_tokens =
-            generate_instruction(storage, instruction, &spec.classes, spec.field_order.clone());
+        let instr_tokens = generate_instruction(
+            storage,
+            instruction,
+            &spec.classes,
+            spec.field_order.clone(),
+        );
         tokens.extend(instr_tokens);
     }
 
@@ -298,7 +300,7 @@ pub fn generate_field_methods(
 
     let machine_elements: Vec<&MachineElement> = match field_order {
         FieldOrder::LsbFirst => instr.machine.layout.iter().collect(),
-        FieldOrder::MsbFirst => instr.machine.layout.iter().rev().collect()
+        FieldOrder::MsbFirst => instr.machine.layout.iter().rev().collect(),
     };
 
     for me in machine_elements {
@@ -637,14 +639,18 @@ pub fn generate_assembly_parser(
                     let class =
                         class_map.get(class_name).unwrap_or_else(|| {
                             panic!("class {class_name} couldn't be found")
-                    });
+                        });
                     if !class.instances.is_empty() {
                         // generate a match between instance names and values
-                        let match_arms: Vec<TokenStream> = class.instances.iter().map(|i| {
-                            let name = &i.name;
-                            let value = i.value;
-                            quote!{ #name => Some(#value) } 
-                        }).collect();
+                        let match_arms: Vec<TokenStream> = class
+                            .instances
+                            .iter()
+                            .map(|i| {
+                                let name = &i.name;
+                                let value = i.value;
+                                quote! { #name => Some(#value) }
+                            })
+                            .collect();
 
                         tks.extend(quote! {
                             let #field: u64 = winnow::combinator::alt((
@@ -658,20 +664,17 @@ pub fn generate_assembly_parser(
                                 isf::parse::number_parser,
                             )).parse_next(input)?;
                         });
-                    }
-                    else {
+                    } else {
                         tks.extend(quote! {
                         let #field: u64 = isf::parse::number_parser.parse_next(input)?;
-                        
+
                         })
                     }
-                }
-                else {
+                } else {
                     tks.extend(quote! {
                     let #field: u64 = isf::parse::number_parser.parse_next(input)?;
-                    
+
                     })
-                    
                 }
 
                 if field_info.width == 1 {

--- a/isf/src/codegen.rs
+++ b/isf/src/codegen.rs
@@ -5,9 +5,12 @@
 //! This module contains a Rust codegen implementation for ISF. The
 //! [`generate`] function produces Rust code from an ISF `[spec::Spec]`.
 
-use std::{collections::BTreeMap, fs::read_to_string};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs::read_to_string,
+};
 
-use crate::spec::{self, AssemblyElement, MachineElement};
+use crate::spec::{self, AssemblyElement, FieldOrder, Class, MachineElement};
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::Ident;
@@ -31,14 +34,20 @@ pub fn generate_code(path: &str) -> anyhow::Result<String> {
 /// generated structs implement the [`AssemblyInstruction`] and
 /// [`MachineInstruction`] traits. They also contain getter and setter
 /// methods for each field.
-pub fn generate(spec: &spec::Spec) -> TokenStream {
+pub fn generate(
+    spec: &spec::Spec,
+) -> TokenStream {
     let mut tokens = TokenStream::default();
     let storage = uint_size(spec.instruction_width);
 
     for instruction in &spec.instructions {
-        let instr_tokens = generate_instruction(storage, instruction);
+        let instr_tokens =
+            generate_instruction(storage, instruction, &spec.classes, spec.field_order.clone());
         tokens.extend(instr_tokens);
     }
+
+    let dispatch = generate_dispatch(&spec.instructions, storage);
+    tokens.extend(dispatch);
 
     tokens
 }
@@ -46,13 +55,15 @@ pub fn generate(spec: &spec::Spec) -> TokenStream {
 pub fn generate_instruction(
     storage: usize,
     instr: &spec::Instruction,
+    class_map: &HashMap<String, Class>,
+    field_order: FieldOrder,
 ) -> TokenStream {
     let name = format_ident!("{}", instr.name);
     let storage = format_ident!("u{storage}");
 
     let default_impl = generate_default_impl(instr);
-    let field_methods = generate_field_methods(instr, &storage);
-    let assembly_parser = generate_assembly_parser(instr);
+    let field_methods = generate_field_methods(instr, &storage, field_order);
+    let assembly_parser = generate_assembly_parser(instr, class_map);
     let assembly_emitter = generate_assembly_emitter(instr);
     let machine_parser = generate_machine_parser(instr);
 
@@ -274,8 +285,10 @@ pub fn generate_assembly_emitter(instr: &spec::Instruction) -> TokenStream {
 pub fn generate_field_methods(
     instr: &spec::Instruction,
     storage: &Ident,
+    field_order: FieldOrder,
 ) -> TokenStream {
     let mut tks = TokenStream::default();
+
     let mut offset = 0usize;
 
     let mut setters = BTreeMap::<String, (bool, Ident, TokenStream)>::default();
@@ -283,7 +296,12 @@ pub fn generate_field_methods(
     let mut set_indicators = BTreeMap::<String, TokenStream>::default();
     let mut mark_unset = BTreeMap::<String, TokenStream>::default();
 
-    for me in &instr.machine.layout {
+    let machine_elements: Vec<&MachineElement> = match field_order {
+        FieldOrder::LsbFirst => instr.machine.layout.iter().collect(),
+        FieldOrder::MsbFirst => instr.machine.layout.iter().rev().collect()
+    };
+
+    for me in machine_elements {
         let (
             name,
             width,
@@ -526,7 +544,10 @@ pub fn generate_field_methods(
     tks
 }
 
-pub fn generate_assembly_parser(instr: &spec::Instruction) -> TokenStream {
+pub fn generate_assembly_parser(
+    instr: &spec::Instruction,
+    class_map: &HashMap<String, spec::Class>,
+) -> TokenStream {
     let mut tks = TokenStream::default();
 
     if instr.fields.is_empty() {
@@ -611,14 +632,54 @@ pub fn generate_assembly_parser(instr: &spec::Instruction) -> TokenStream {
                 let field_info = instr
                     .get_field(name)
                     .unwrap_or_else(|| panic!("field {name} undefined"));
+
+                if let Some(class_name) = &field_info.class {
+                    let class =
+                        class_map.get(class_name).unwrap_or_else(|| {
+                            panic!("class {class_name} couldn't be found")
+                    });
+                    if !class.instances.is_empty() {
+                        // generate a match between instance names and values
+                        let match_arms: Vec<TokenStream> = class.instances.iter().map(|i| {
+                            let name = &i.name;
+                            let value = i.value;
+                            quote!{ #name => Some(#value) } 
+                        }).collect();
+
+                        tks.extend(quote! {
+                            let #field: u64 = winnow::combinator::alt((
+                                isf::parse::identifier_parser_nospace
+                                    .verify_map(|token: String| {
+                                        match token.as_str() {
+                                            #(#match_arms),*,
+                                            _ => None
+                                        }
+                                    }),
+                                isf::parse::number_parser,
+                            )).parse_next(input)?;
+                        });
+                    }
+                    else {
+                        tks.extend(quote! {
+                        let #field: u64 = isf::parse::number_parser.parse_next(input)?;
+                        
+                        })
+                    }
+                }
+                else {
+                    tks.extend(quote! {
+                    let #field: u64 = isf::parse::number_parser.parse_next(input)?;
+                    
+                    })
+                    
+                }
+
                 if field_info.width == 1 {
                     tks.extend(quote! {
-                        let #field: u64 = isf::parse::number_parser.parse_next(input)?;
                         result.#setter(#field != 0);
                     });
                 } else {
                     tks.extend(quote! {
-                        let #field: u64 = isf::parse::number_parser.parse_next(input)?;
                         result.#setter(#field.try_into().unwrap());
                     });
                 }
@@ -630,6 +691,30 @@ pub fn generate_assembly_parser(instr: &spec::Instruction) -> TokenStream {
     });
 
     tks
+}
+
+pub fn generate_dispatch(
+    instructions: &[spec::Instruction],
+    storage: usize,
+) -> TokenStream {
+    let storage_type = format_ident!("u{storage}");
+    let names: Vec<Ident> = instructions
+        .iter()
+        .map(|instr| format_ident!("{}", instr.name))
+        .collect();
+
+    quote! {
+        pub fn parse_instruction(text: &str) -> Option<#storage_type> {
+            use isf::AssemblyInstruction;
+            use isf::MachineInstruction;
+            #(
+                if let Ok(inst) = #names::parse_assembly(text) {
+                    return Some(inst.emit_machine());
+                }
+            )*
+            None
+        }
+    }
 }
 
 fn uint_size(bits: usize) -> usize {

--- a/isf/src/codegen.rs
+++ b/isf/src/codegen.rs
@@ -707,6 +707,14 @@ pub fn generate_dispatch(
         .collect();
 
     quote! {
+        #[doc = " Assemble a single instruction from its assembly text into a machine word."]
+        #[doc = ""]
+        #[doc = " `text` must contain exactly one instruction: each candidate instruction is"]
+        #[doc = " parsed with [`isf::AssemblyInstruction::parse_assembly`], which requires the"]
+        #[doc = " *entire* input to be consumed. Any trailing content (a second instruction, a"]
+        #[doc = " comment, stray whitespace) causes that candidate to fail, so multi-line or"]
+        #[doc = " multi-instruction input returns `None`. Returns the machine encoding of the"]
+        #[doc = " first instruction whose syntax matches, or `None` if none do."]
         pub fn parse_instruction(text: &str) -> Option<#storage_type> {
             use isf::AssemblyInstruction;
             use isf::MachineInstruction;

--- a/isf/src/parse.rs
+++ b/isf/src/parse.rs
@@ -13,7 +13,7 @@ use winnow::{
     },
     combinator::{alt, cut_err, repeat, separated, trace},
     error::{ContextError, StrContext},
-    token::{none_of, take_until},
+    token::{none_of, take_until, take_while},
     ModalResult, Parser,
 };
 
@@ -515,6 +515,12 @@ pub fn number_parser(input: &mut &str) -> ModalResult<u64> {
     if s("0x").parse_next(input).is_ok() {
         let s = hex_digit1.parse_next(input)?;
         let n = u64::from_str_radix(s, 16).unwrap();
+        Ok(n)
+    } else if s("0b").parse_next(input).is_ok() {
+        let s = take_while(1.., |c: char| c == '0' || c == '1' || c == '_')
+            .parse_next(input)?;
+        let clean: String = s.chars().filter(|c| *c != '_').collect();
+        let n = u64::from_str_radix(&clean, 2).unwrap();
         Ok(n)
     } else {
         let s = digit1.parse_next(input)?;

--- a/isf/src/spec.rs
+++ b/isf/src/spec.rs
@@ -31,7 +31,6 @@ pub struct ClassInstance {
     pub value: u64,
 }
 
-
 #[derive(Debug, Clone, Default)]
 pub struct Class {
     pub doc: String,

--- a/isf/src/spec.rs
+++ b/isf/src/spec.rs
@@ -10,19 +10,34 @@ use std::collections::HashMap;
 use crate::ast::{self, Base, BaseParameter, Timing};
 use anyhow::{anyhow, Result};
 
+#[derive(Debug, Clone)]
+pub enum FieldOrder {
+    LsbFirst,
+    MsbFirst,
+}
+
 /// Concrete ISF specification resolved from ISF AST.
 #[derive(Debug)]
 pub struct Spec {
     pub instruction_width: usize,
+    pub field_order: FieldOrder,
     pub instructions: Vec<Instruction>,
     pub classes: HashMap<String, Class>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
+pub struct ClassInstance {
+    pub name: String,
+    pub value: u64,
+}
+
+
+#[derive(Debug, Clone, Default)]
 pub struct Class {
     pub doc: String,
     pub name: String,
     pub width: usize,
+    pub instances: Vec<ClassInstance>,
 }
 
 /// Concrete instruction. Base instruction elements fully incorporated.
@@ -323,7 +338,7 @@ impl Instruction {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct Field {
     pub doc: String,
     pub name: String,
@@ -434,6 +449,7 @@ pub fn form_spec(ast: &ast::Ast) -> Result<Spec> {
                     name: c.name.clone(),
                     doc: c.doc.clone(),
                     width: c.width,
+                    instances: Vec::new(),
                 },
             )
         })
@@ -449,6 +465,7 @@ pub fn form_spec(ast: &ast::Ast) -> Result<Spec> {
 
     Ok(Spec {
         instruction_width,
+        field_order: FieldOrder::LsbFirst,
         instructions,
         classes,
     })

--- a/isf/testcase/add.rs
+++ b/isf/testcase/add.rs
@@ -109,6 +109,14 @@ impl isf::MachineInstruction<u32> for Add {
         self.0
     }
 }
+/// Assemble a single instruction from its assembly text into a machine word.
+///
+/// `text` must contain exactly one instruction: each candidate instruction is
+/// parsed with [`isf::AssemblyInstruction::parse_assembly`], which requires the
+/// *entire* input to be consumed. Any trailing content (a second instruction, a
+/// comment, stray whitespace) causes that candidate to fail, so multi-line or
+/// multi-instruction input returns `None`. Returns the machine encoding of the
+/// first instruction whose syntax matches, or `None` if none do.
 pub fn parse_instruction(text: &str) -> Option<u32> {
     use isf::AssemblyInstruction;
     use isf::MachineInstruction;

--- a/isf/testcase/add.rs
+++ b/isf/testcase/add.rs
@@ -109,3 +109,11 @@ impl isf::MachineInstruction<u32> for Add {
         self.0
     }
 }
+pub fn parse_instruction(text: &str) -> Option<u32> {
+    use isf::AssemblyInstruction;
+    use isf::MachineInstruction;
+    if let Ok(inst) = Add::parse_assembly(text) {
+        return Some(inst.emit_machine());
+    }
+    None
+}

--- a/isf/testcase/add_field_opt.rs
+++ b/isf/testcase/add_field_opt.rs
@@ -150,3 +150,11 @@ impl isf::MachineInstruction<u32> for AddOptField {
         self.0
     }
 }
+pub fn parse_instruction(text: &str) -> Option<u32> {
+    use isf::AssemblyInstruction;
+    use isf::MachineInstruction;
+    if let Ok(inst) = AddOptField::parse_assembly(text) {
+        return Some(inst.emit_machine());
+    }
+    None
+}

--- a/isf/testcase/add_field_opt.rs
+++ b/isf/testcase/add_field_opt.rs
@@ -150,6 +150,14 @@ impl isf::MachineInstruction<u32> for AddOptField {
         self.0
     }
 }
+/// Assemble a single instruction from its assembly text into a machine word.
+///
+/// `text` must contain exactly one instruction: each candidate instruction is
+/// parsed with [`isf::AssemblyInstruction::parse_assembly`], which requires the
+/// *entire* input to be consumed. Any trailing content (a second instruction, a
+/// comment, stray whitespace) causes that candidate to fail, so multi-line or
+/// multi-instruction input returns `None`. Returns the machine encoding of the
+/// first instruction whose syntax matches, or `None` if none do.
 pub fn parse_instruction(text: &str) -> Option<u32> {
     use isf::AssemblyInstruction;
     use isf::MachineInstruction;

--- a/isf/testcase/slice_add.rs
+++ b/isf/testcase/slice_add.rs
@@ -97,6 +97,14 @@ impl isf::MachineInstruction<u32> for SliceAdd {
         self.0
     }
 }
+/// Assemble a single instruction from its assembly text into a machine word.
+///
+/// `text` must contain exactly one instruction: each candidate instruction is
+/// parsed with [`isf::AssemblyInstruction::parse_assembly`], which requires the
+/// *entire* input to be consumed. Any trailing content (a second instruction, a
+/// comment, stray whitespace) causes that candidate to fail, so multi-line or
+/// multi-instruction input returns `None`. Returns the machine encoding of the
+/// first instruction whose syntax matches, or `None` if none do.
 pub fn parse_instruction(text: &str) -> Option<u32> {
     use isf::AssemblyInstruction;
     use isf::MachineInstruction;

--- a/isf/testcase/slice_add.rs
+++ b/isf/testcase/slice_add.rs
@@ -97,3 +97,11 @@ impl isf::MachineInstruction<u32> for SliceAdd {
         self.0
     }
 }
+pub fn parse_instruction(text: &str) -> Option<u32> {
+    use isf::AssemblyInstruction;
+    use isf::MachineInstruction;
+    if let Ok(inst) = SliceAdd::parse_assembly(text) {
+        return Some(inst.emit_machine());
+    }
+    None
+}


### PR DESCRIPTION
This adds some extra bits to ISF to make it easier to generate assembly parsers. ISF's main consumer before this was the HTQ work which lowered to its internal assembly representation and then invoked ISF to generate machine code. With the softcore, we are ingesting human-readable assembly files and then generating machine code.

- Allow for register mnemonics: this is mainly for ergonomics when writing assembly as it's a pain to try and remember register numbers for the packet field registers. This is implemented via classes at the moment. 

- Generate a parser for all the instructions: this collects all the instructions into a single parser so it can be run on a line of assembly. Notably, this is done via generated if statements rather than `winnow`'s `alt` combinator. This is because [`alt` has a limit of 21 elements](https://docs.rs/winnow/latest/winnow/combinator/trait.Alt.html) and there is no guarantee on there being 21 instructions or fewer in an ISA. It also will ingest the whole input that you give it and will only return a parsed instruction is there is nothing else on that line. 

- Allow binary constants in assembly: Numbers prefixed with 0b are interpreted as binary.

- Add a u26 field: this is for a jump instruction offset. Possibly the immediate handling should be made more general, so we're not creating a new macro for every different width 